### PR TITLE
Add map service interface and dummy implementation

### DIFF
--- a/src/TourPlanner.Application/Contracts/RouteResult.cs
+++ b/src/TourPlanner.Application/Contracts/RouteResult.cs
@@ -1,0 +1,4 @@
+namespace TourPlanner.Application.Contracts;
+
+public sealed record RouteResult(double DistanceKm, TimeSpan EstimatedTime);
+

--- a/src/TourPlanner.Application/Interfaces/IMapService.cs
+++ b/src/TourPlanner.Application/Interfaces/IMapService.cs
@@ -1,0 +1,9 @@
+using TourPlanner.Application.Contracts;
+
+namespace TourPlanner.Application.Interfaces;
+
+public interface IMapService
+{
+    Task<RouteResult> CalculateRouteAsync(string from, string to);
+}
+

--- a/src/TourPlanner.Infrastructure/Services/MapService.cs
+++ b/src/TourPlanner.Infrastructure/Services/MapService.cs
@@ -1,0 +1,14 @@
+using TourPlanner.Application.Contracts;
+using TourPlanner.Application.Interfaces;
+
+namespace TourPlanner.Infrastructure.Services;
+
+public sealed class MapService : IMapService
+{
+    public Task<RouteResult> CalculateRouteAsync(string from, string to)
+    {
+        var result = new RouteResult(42, TimeSpan.FromHours(1));
+        return Task.FromResult(result);
+    }
+}
+

--- a/tests/TourPlanner.Tests/Infrastructure/MapServiceTests.cs
+++ b/tests/TourPlanner.Tests/Infrastructure/MapServiceTests.cs
@@ -1,0 +1,17 @@
+using TourPlanner.Infrastructure.Services;
+using Xunit;
+
+namespace TourPlanner.Tests.Infrastructure;
+
+public class MapServiceTests
+{
+    [Fact]
+    public async Task CalculateRoute_Returns_FixedValues()
+    {
+        var svc = new MapService();
+        var result = await svc.CalculateRouteAsync("A", "B");
+        Assert.Equal(42, result.DistanceKm);
+        Assert.Equal(TimeSpan.FromHours(1), result.EstimatedTime);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RouteResult DTO for route calculation results
- define IMapService interface
- implement MapService returning fixed distance and ETA
- test MapService dummy response

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b49f1629e0832383d4af4455fb2b4a