### PR TITLE
feat: add serilog logging and map view with webview2

### DIFF
--- a/src/TourPlanner.Application/Contracts/RouteResult.cs
+++ b/src/TourPlanner.Application/Contracts/RouteResult.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
+
 namespace TourPlanner.Application.Contracts;
 
-public sealed record RouteResult(double DistanceKm, TimeSpan EstimatedTime);
+public sealed record RouteResult(double DistanceKm, TimeSpan EstimatedTime, IReadOnlyList<(double Lat, double Lng)> Path);
 

--- a/src/TourPlanner.Application/Interfaces/IMapService.cs
+++ b/src/TourPlanner.Application/Interfaces/IMapService.cs
@@ -1,9 +1,10 @@
 using TourPlanner.Application.Contracts;
+using System.Threading;
 
 namespace TourPlanner.Application.Interfaces;
 
 public interface IMapService
 {
-    Task<RouteResult> CalculateRouteAsync(string from, string to);
+    Task<RouteResult> GetRouteAsync(string from, string to, CancellationToken ct = default);
 }
 

--- a/src/TourPlanner.Infrastructure/DependencyInjection.cs
+++ b/src/TourPlanner.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TourPlanner.Application.Interfaces;
+using TourPlanner.Infrastructure.Persistence;
+using TourPlanner.Infrastructure.Repositories;
+using TourPlanner.Infrastructure.Services;
+
+namespace TourPlanner.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration cfg)
+    {
+        var useEf = cfg.GetValue("Data:UseEf", false);
+        if (useEf)
+        {
+            var cs = cfg.GetConnectionString("Postgres")!;
+            services.AddDbContext<AppDbContext>(o => o.UseNpgsql(cs));
+            services.AddScoped<ITourRepository, EfTourRepository>();
+            services.AddScoped<ITourLogRepository, EfTourLogRepository>();
+        }
+        else
+        {
+            services.AddSingleton<ITourRepository, InMemoryTourRepository>();
+        }
+
+        services.AddSingleton<IMapService, MapService>();
+
+        return services;
+    }
+}

--- a/src/TourPlanner.Infrastructure/Services/MapService.cs
+++ b/src/TourPlanner.Infrastructure/Services/MapService.cs
@@ -1,13 +1,21 @@
 using TourPlanner.Application.Contracts;
 using TourPlanner.Application.Interfaces;
+using System.Collections.Generic;
 
 namespace TourPlanner.Infrastructure.Services;
 
 public sealed class MapService : IMapService
 {
-    public Task<RouteResult> CalculateRouteAsync(string from, string to)
+    public Task<RouteResult> GetRouteAsync(string from, string to, System.Threading.CancellationToken ct = default)
     {
-        var result = new RouteResult(42, TimeSpan.FromHours(1));
+        ct.ThrowIfCancellationRequested();
+        var path = new List<(double Lat, double Lng)>
+        {
+            (48.2082, 16.3738),
+            (48.2100, 16.3600),
+            (48.2150, 16.3400)
+        };
+        var result = new RouteResult(42, TimeSpan.FromHours(1), path);
         return Task.FromResult(result);
     }
 }

--- a/src/TourPlanner.UI/App.xaml.cs
+++ b/src/TourPlanner.UI/App.xaml.cs
@@ -2,10 +2,11 @@ using System.Windows;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Serilog;
 using TourPlanner.Application.Interfaces;
 using TourPlanner.Application.Services;
-using TourPlanner.Infrastructure.Repositories;
 using TourPlanner.UI.ViewModels;
+using TourPlanner.Infrastructure;
 
 // Alias, damit "Application" eindeutig der WPF-Typ ist
 using WpfApplication = System.Windows.Application;
@@ -17,28 +18,36 @@ public partial class App : WpfApplication
     public static IHost AppHost { get; private set; } = Host.CreateDefaultBuilder()
         .ConfigureAppConfiguration(cfg =>
         {
-            cfg.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+            cfg.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+        })
+        .UseSerilog((ctx, log) =>
+        {
+            log.MinimumLevel.Information()
+               .WriteTo.File("logs/app-.log", rollingInterval: RollingInterval.Day);
         })
         .ConfigureServices((context, services) =>
         {
-            // Infrastructure
-            services.AddSingleton<ITourRepository, InMemoryTourRepository>();
+            services.AddInfrastructure(context.Configuration);
 
-            // Application (BL)
             services.AddSingleton<ITourService, TourService>();
+            services.AddSingleton<ITourLogService, TourLogService>();
 
-            // UI
+            services.AddSingleton<MapViewModel>();
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<Views.MainWindow>(sp =>
-            {
-                var vm = sp.GetRequiredService<MainViewModel>();
-                return new Views.MainWindow { DataContext = vm };
-            });
+                new Views.MainWindow { DataContext = sp.GetRequiredService<MainViewModel>() });
         })
         .Build();
 
     protected override async void OnStartup(StartupEventArgs e)
     {
+        this.DispatcherUnhandledException += (s, args) =>
+        {
+            Log.Error(args.Exception, "Unhandled UI exception");
+            MessageBox.Show(args.Exception.Message, "Unexpected error", MessageBoxButton.OK, MessageBoxImage.Error);
+            args.Handled = true;
+        };
+
         await AppHost.StartAsync();
         AppHost.Services.GetRequiredService<Views.MainWindow>().Show();
         base.OnStartup(e);

--- a/src/TourPlanner.UI/TourPlanner.UI.csproj
+++ b/src/TourPlanner.UI/TourPlanner.UI.csproj
@@ -11,11 +11,20 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\TourPlanner.Application\TourPlanner.Application.csproj" />
     <ProjectReference Include="..\TourPlanner.Infrastructure\TourPlanner.Infrastructure.csproj" />
     <ProjectReference Include="..\TourPlanner.Domain\TourPlanner.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="wwwroot\map\index.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/TourPlanner.UI/ViewModels/MainViewModel.cs
+++ b/src/TourPlanner.UI/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
 using TourPlanner.UI.Models;
 
 namespace TourPlanner.UI.ViewModels
@@ -16,12 +17,17 @@ namespace TourPlanner.UI.ViewModels
             get => _statusMessage;
             set { _statusMessage = value; OnPropertyChanged(); }
         }
+        public string DataMode { get; }
 
         public TourListViewModel TourList { get; }
         public TourDetailViewModel TourDetail { get; }
+        public MapViewModel MapVm { get; }
 
-        public MainViewModel()
+        public MainViewModel(MapViewModel mapVm, IConfiguration cfg)
         {
+            MapVm = mapVm;
+            DataMode = cfg.GetValue("Data:UseEf", false) ? "DB: EF/Postgres" : "DB: InMemory";
+
             var tours = new ObservableCollection<Tour>
             {
                 new Tour { Name = "Vienna City Walk", From = "Stephansplatz", To = "Belvedere", DistanceKm = 4.2 },

--- a/src/TourPlanner.UI/ViewModels/MapViewModel.cs
+++ b/src/TourPlanner.UI/ViewModels/MapViewModel.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using TourPlanner.Application.Interfaces;
+using TourPlanner.UI.Commands;
+
+namespace TourPlanner.UI.ViewModels;
+
+public sealed class MapViewModel : INotifyPropertyChanged
+{
+    private readonly IMapService _mapService;
+    private string? _from;
+    private string? _to;
+
+    public Func<IEnumerable<(double Lat, double Lng)>, Task>? DrawRouteOnMap { get; set; }
+
+    public string? From
+    {
+        get => _from;
+        set { _from = value; OnPropertyChanged(); }
+    }
+
+    public string? To
+    {
+        get => _to;
+        set { _to = value; OnPropertyChanged(); }
+    }
+
+    public ICommand ShowRouteCommand { get; }
+
+    public MapViewModel(IMapService mapService)
+    {
+        _mapService = mapService;
+        ShowRouteCommand = new RelayCommand(async _ => await ShowAsync(), _ =>
+            !string.IsNullOrWhiteSpace(From) && !string.IsNullOrWhiteSpace(To));
+    }
+
+    private async Task ShowAsync()
+    {
+        try
+        {
+            var result = await _mapService.GetRouteAsync(From!, To!);
+            if (result.Path.Count > 0)
+            {
+                if (DrawRouteOnMap != null)
+                    await DrawRouteOnMap(result.Path);
+            }
+            else
+            {
+                MessageBox.Show("No route found.", "Route", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(ex.Message, "Route error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/src/TourPlanner.UI/Views/MainWindow.xaml
+++ b/src/TourPlanner.UI/Views/MainWindow.xaml
@@ -13,23 +13,30 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="420" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
 
-        <!-- Master (list) -->
-        <local:TourListView Grid.Row="0" Grid.Column="0"
-                            DataContext="{Binding TourList}" />
+        <TabControl Grid.Row="0">
+            <TabItem Header="Tours">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="420" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-        <!-- Detail (properties + logs) -->
-        <local:TourDetailView Grid.Row="0" Grid.Column="1"
-                              DataContext="{Binding TourDetail}" />
+                    <local:TourListView Grid.Column="0" DataContext="{Binding TourList}" />
+                    <local:TourDetailView Grid.Column="1" DataContext="{Binding TourDetail}" />
+                </Grid>
+            </TabItem>
+            <TabItem Header="Map">
+                <local:MapView DataContext="{Binding MapVm}" />
+            </TabItem>
+        </TabControl>
 
-        <!-- Statusbar -->
-        <StatusBar Grid.Row="1" Grid.ColumnSpan="2">
+        <StatusBar Grid.Row="1">
             <StatusBarItem>
                 <TextBlock Text="{Binding StatusMessage}" />
+            </StatusBarItem>
+            <StatusBarItem HorizontalAlignment="Right">
+                <TextBlock Text="{Binding DataMode}" />
             </StatusBarItem>
         </StatusBar>
     </Grid>

--- a/src/TourPlanner.UI/Views/MainWindow.xaml.cs
+++ b/src/TourPlanner.UI/Views/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
 using System.Windows;
-using TourPlanner.UI.ViewModels;
 
 namespace TourPlanner.UI.Views
 {
@@ -8,7 +7,6 @@ namespace TourPlanner.UI.Views
         public MainWindow()
         {
             InitializeComponent();
-            DataContext = new MainViewModel();
         }
     }
 }

--- a/src/TourPlanner.UI/Views/MapView.xaml
+++ b/src/TourPlanner.UI/Views/MapView.xaml
@@ -1,0 +1,19 @@
+<UserControl x:Class="TourPlanner.UI.Views.MapView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf">
+  <Grid Margin="8">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto"/>
+      <RowDefinition Height="*"/>
+    </Grid.RowDefinitions>
+
+    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+      <TextBox Width="220" Text="{Binding From, UpdateSourceTrigger=PropertyChanged}"/>
+      <TextBox Width="220" Margin="8,0,0,0" Text="{Binding To, UpdateSourceTrigger=PropertyChanged}"/>
+      <Button Margin="8,0,0,0" Content="Show Route" Command="{Binding ShowRouteCommand}"/>
+    </StackPanel>
+
+    <wv2:WebView2 x:Name="Map" Grid.Row="1" Loaded="OnLoaded"/>
+  </Grid>
+</UserControl>

--- a/src/TourPlanner.UI/Views/MapView.xaml.cs
+++ b/src/TourPlanner.UI/Views/MapView.xaml.cs
@@ -1,0 +1,35 @@
+using Microsoft.Web.WebView2.Wpf;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using TourPlanner.UI.ViewModels;
+
+namespace TourPlanner.UI.Views;
+
+public partial class MapView : UserControl
+{
+    public MapView()
+    {
+        InitializeComponent();
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        await Map.EnsureCoreWebView2Async();
+        var htmlPath = Path.Combine(AppContext.BaseDirectory, "wwwroot", "map", "index.html");
+        Map.Source = new Uri(htmlPath);
+        if (DataContext is MapViewModel vm)
+        {
+            vm.DrawRouteOnMap = async coords =>
+            {
+                var latlngs = coords.Select(c => new[] { c.Lat, c.Lng });
+                var json = JsonSerializer.Serialize(latlngs);
+                await Map.CoreWebView2.ExecuteScriptAsync($"window.drawRoute({json})");
+            };
+        }
+    }
+}

--- a/src/TourPlanner.UI/appsettings.json
+++ b/src/TourPlanner.UI/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "Data": { "UseEf": false },
   "ConnectionStrings": {
     "Postgres": "Host=localhost;Port=5432;Database=tourplanner;Username=postgres;Password=postgres"
   },

--- a/src/TourPlanner.UI/wwwroot/map/index.html
+++ b/src/TourPlanner.UI/wwwroot/map/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+  <style>html,body,#map{height:100%;margin:0}</style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script>
+    const map = L.map('map').setView([48.2082, 16.3738], 12);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      {maxZoom:19, attribution:'© OpenStreetMap'}).addTo(map);
+    window.drawRoute = function(latlngs){
+      if(!latlngs || !latlngs.length) return;
+      if(window._poly) { map.removeLayer(window._poly); }
+      window._poly = L.polyline(latlngs, {weight:4});
+      window._poly.addTo(map);
+      map.fitBounds(window._poly.getBounds(), {padding:[20,20]});
+    };
+  </script>
+</body>
+</html>

--- a/tests/TourPlanner.Tests/Infrastructure/MapServiceTests.cs
+++ b/tests/TourPlanner.Tests/Infrastructure/MapServiceTests.cs
@@ -6,12 +6,13 @@ namespace TourPlanner.Tests.Infrastructure;
 public class MapServiceTests
 {
     [Fact]
-    public async Task CalculateRoute_Returns_FixedValues()
+    public async Task GetRoute_Returns_FixedValues()
     {
         var svc = new MapService();
-        var result = await svc.CalculateRouteAsync("A", "B");
+        var result = await svc.GetRouteAsync("A", "B");
         Assert.Equal(42, result.DistanceKm);
         Assert.Equal(TimeSpan.FromHours(1), result.EstimatedTime);
+        Assert.True(result.Path.Count > 0);
     }
 }
 


### PR DESCRIPTION
## Summary
- add Serilog file logging and global exception handler
- switch between EF/Postgres and in-memory repositories via configuration
- integrate Leaflet map in new Map tab using WebView2 and stub IMapService

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b55350daac8323bbbd285b6b45b75a