### PR TITLE
refactor ui viewmodels to use services

### DIFF
--- a/src/TourPlanner.UI/App.xaml.cs
+++ b/src/TourPlanner.UI/App.xaml.cs
@@ -33,6 +33,8 @@ public partial class App : WpfApplication
             services.AddSingleton<ITourLogService, TourLogService>();
 
             services.AddSingleton<MapViewModel>();
+            services.AddSingleton<TourListViewModel>();
+            services.AddSingleton<TourDetailViewModel>();
             services.AddSingleton<MainViewModel>();
             services.AddSingleton<Views.MainWindow>(sp =>
                 new Views.MainWindow { DataContext = sp.GetRequiredService<MainViewModel>() });

--- a/src/TourPlanner.UI/ViewModels/MainViewModel.cs
+++ b/src/TourPlanner.UI/ViewModels/MainViewModel.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Configuration;
-using TourPlanner.UI.Models;
 
 namespace TourPlanner.UI.ViewModels
 {
@@ -23,21 +21,13 @@ namespace TourPlanner.UI.ViewModels
         public TourDetailViewModel TourDetail { get; }
         public MapViewModel MapVm { get; }
 
-        public MainViewModel(MapViewModel mapVm, IConfiguration cfg)
+        public MainViewModel(MapViewModel mapVm, TourListViewModel listVm, TourDetailViewModel detailVm, IConfiguration cfg)
         {
             MapVm = mapVm;
+            TourList = listVm;
+            TourDetail = detailVm;
             DataMode = cfg.GetValue("Data:UseEf", false) ? "DB: EF/Postgres" : "DB: InMemory";
 
-            var tours = new ObservableCollection<Tour>
-            {
-                new Tour { Name = "Vienna City Walk", From = "Stephansplatz", To = "Belvedere", DistanceKm = 4.2 },
-                new Tour { Name = "Wachau Day Trip", From = "Krems", To = "Dürnstein", DistanceKm = 12.7 },
-                new Tour { Name = "Salzburg Old Town", From = "Mirabell", To = "Hohensalzburg", DistanceKm = 3.8 },
-            };
-
-            TourList = new TourListViewModel(tours, msg => StatusMessage = msg);
-            TourDetail = new TourDetailViewModel();
-            
             TourList.PropertyChanged += (_, e) =>
             {
                 if (e.PropertyName == nameof(TourListViewModel.SelectedTour))
@@ -45,157 +35,13 @@ namespace TourPlanner.UI.ViewModels
                     TourDetail.SelectedTour = TourList.SelectedTour;
                 }
             };
+
+            TourList.Status += msg => StatusMessage = msg;
+            TourDetail.TourUpdated += t => TourList.ReplaceTour(t);
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;
         protected void OnPropertyChanged([CallerMemberName] string? name = null)
             => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-    }
-}
-
-namespace TourPlanner.UI.Models
-{
-    using System.Collections.Generic;
-    using System.Linq;
-
-    public class Tour : INotifyPropertyChanged, INotifyDataErrorInfo
-    {
-        private string _name = "";
-        private string _from = "";
-        private string _to = "";
-        private double _distanceKm;
-
-        public Guid Id { get; } = Guid.NewGuid();
-
-        public string Name
-        {
-            get => _name;
-            set { _name = value; Validate(); OnPropertyChanged(); }
-        }
-
-        public string From
-        {
-            get => _from;
-            set { _from = value; OnPropertyChanged(); }
-        }
-
-        public string To
-        {
-            get => _to;
-            set { _to = value; OnPropertyChanged(); }
-        }
-
-        public double DistanceKm
-        {
-            get => _distanceKm;
-            set { _distanceKm = value; OnPropertyChanged(); }
-        }
-
-        public ObservableCollection<TourLog> Logs { get; } = new();
-
-        #region INotifyPropertyChanged
-        public event PropertyChangedEventHandler? PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string? name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        #endregion
-
-        #region Validation (INotifyDataErrorInfo)
-        private readonly Dictionary<string, List<string>> _errors = new();
-
-        public bool HasErrors => _errors.Count > 0;
-        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
-        public System.Collections.IEnumerable GetErrors(string? propertyName)
-        {
-            if (propertyName != null && _errors.TryGetValue(propertyName, out var list))
-                return list;
-            return Enumerable.Empty<string>();
-        }
-
-        private void Validate()
-        {
-            SetErrors(nameof(Name),
-                string.IsNullOrWhiteSpace(Name) || Name.Trim().Length < 3
-                    ? new[] { "Name must be at least 3 characters." }
-                    : Array.Empty<string>());
-        }
-
-        private void SetErrors(string propertyName, IEnumerable<string> errors)
-        {
-            var list = errors.ToList();
-            if (list.Count == 0)
-            {
-                if (_errors.Remove(propertyName))
-                    ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-                return;
-            }
-
-            _errors[propertyName] = list;
-            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-        }
-        #endregion
-    }
-
-    public class TourLog : INotifyPropertyChanged, INotifyDataErrorInfo
-    {
-        private DateTime _date = DateTime.Today;
-        private int _rating = 3;
-        private string _notes = "";
-
-        public DateTime Date
-        {
-            get => _date;
-            set { _date = value; OnPropertyChanged(); }
-        }
-
-        public int Rating
-        {
-            get => _rating;
-            set { _rating = value; Validate(); OnPropertyChanged(); }
-        }
-
-        public string Notes
-        {
-            get => _notes;
-            set { _notes = value; OnPropertyChanged(); }
-        }
-
-        #region INotifyPropertyChanged
-        public event PropertyChangedEventHandler? PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string? name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-        #endregion
-
-        #region Validation
-        private readonly Dictionary<string, List<string>> _errors = new();
-        public bool HasErrors => _errors.Count > 0;
-        public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
-        public System.Collections.IEnumerable GetErrors(string? propertyName)
-        {
-            if (propertyName != null && _errors.TryGetValue(propertyName, out var list))
-                return list;
-            return Array.Empty<string>();
-        }
-
-        private void Validate()
-        {
-            var errs = new List<string>();
-            if (Rating < 1 || Rating > 5) errs.Add("Rating must be between 1 and 5.");
-            SetErrors(nameof(Rating), errs);
-        }
-
-        private void SetErrors(string propertyName, IEnumerable<string> errors)
-        {
-            var list = errors.ToList();
-            if (list.Count == 0)
-            {
-                if (_errors.Remove(propertyName))
-                    ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-                return;
-            }
-
-            _errors[propertyName] = list;
-            ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
-        }
-        #endregion
     }
 }

--- a/src/TourPlanner.UI/ViewModels/TourDetailViewModel.cs
+++ b/src/TourPlanner.UI/ViewModels/TourDetailViewModel.cs
@@ -1,80 +1,167 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Serilog;
+using TourPlanner.Application.Interfaces;
+using TourPlanner.Domain.Entities;
 using TourPlanner.UI.Commands;
-using TourPlanner.UI.Models;
 
-namespace TourPlanner.UI.ViewModels
+namespace TourPlanner.UI.ViewModels;
+
+public class TourDetailViewModel : INotifyPropertyChanged
 {
-    public class TourDetailViewModel : INotifyPropertyChanged
+    private readonly ITourService _tourService;
+    private readonly ITourLogService _tourLogService;
+    private Tour? _selectedTour;
+    private TourLog? _selectedLog;
+    private string? _name;
+    private string? _description;
+    private double _distanceKm;
+    private DateTime _logDate = DateTime.Today;
+    private int _logRating = 3;
+    private string? _logNotes;
+
+    public ObservableCollection<TourLog> Logs { get; } = new();
+
+    public Tour? SelectedTour
     {
-        private Tour? _selectedTour;
-        private TourLog? _selectedLog;
-
-        public Tour? SelectedTour
+        get => _selectedTour;
+        set
         {
-            get => _selectedTour;
-            set
+            _selectedTour = value;
+            OnPropertyChanged();
+            if (value is not null)
             {
-                _selectedTour = value;
-                OnPropertyChanged();
-                OnPropertyChanged(nameof(Logs));
-                CommandManager.InvalidateRequerySuggested();
+                Name = value.Name;
+                Description = value.Description;
+                DistanceKm = value.DistanceKm;
+                _ = LoadLogsAsync(value.Id);
             }
-        }
-
-        public ObservableCollection<TourLog>? Logs => SelectedTour?.Logs;
-
-        public TourLog? SelectedLog
-        {
-            get => _selectedLog;
-            set
+            else
             {
-                _selectedLog = value;
-                OnPropertyChanged();
-                CommandManager.InvalidateRequerySuggested();
+                Name = null;
+                Description = null;
+                DistanceKm = 0;
+                Logs.Clear();
             }
-        }
-
-        public ICommand AddLogCommand { get; }
-        public ICommand DeleteLogCommand { get; }
-
-        public TourDetailViewModel()
-        {
-            AddLogCommand = new RelayCommand(_ => AddLog(), _ => SelectedTour is not null);
-            DeleteLogCommand = new RelayCommand(_ => DeleteLog(), _ => SelectedLog is not null);
-        }
-
-        private void AddLog()
-        {
-            if (SelectedTour is null) return;
-            var log = new TourLog
-            {
-                Date = DateTime.Today,
-                Rating = 3,
-                Notes = "New log entry"
-            };
-            SelectedTour.Logs.Add(log);
-            Log.Information("Added log to tour {TourName}", SelectedTour.Name);
-            OnPropertyChanged(nameof(Logs));
             CommandManager.InvalidateRequerySuggested();
         }
-
-        private void DeleteLog()
-        {
-            if (SelectedTour is null || SelectedLog is null) return;
-            SelectedTour.Logs.Remove(SelectedLog);
-            Log.Information("Deleted log from tour {TourName}", SelectedTour.Name);
-            SelectedLog = null;
-            OnPropertyChanged(nameof(Logs));
-            CommandManager.InvalidateRequerySuggested();
-        }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string? name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
     }
+
+    public string? Name
+    {
+        get => _name;
+        set { _name = value; OnPropertyChanged(); _ = SaveTourAsync(); }
+    }
+
+    public string? Description
+    {
+        get => _description;
+        set { _description = value; OnPropertyChanged(); _ = SaveTourAsync(); }
+    }
+
+    public double DistanceKm
+    {
+        get => _distanceKm;
+        set { _distanceKm = value; OnPropertyChanged(); _ = SaveTourAsync(); }
+    }
+
+    public TourLog? SelectedLog
+    {
+        get => _selectedLog;
+        set
+        {
+            _selectedLog = value;
+            OnPropertyChanged();
+            if (value is not null)
+            {
+                LogDate = value.Date;
+                LogRating = value.Rating;
+                LogNotes = value.Notes;
+            }
+            CommandManager.InvalidateRequerySuggested();
+        }
+    }
+
+    public DateTime LogDate
+    {
+        get => _logDate;
+        set { _logDate = value; OnPropertyChanged(); _ = SaveLogAsync(); }
+    }
+
+    public int LogRating
+    {
+        get => _logRating;
+        set { _logRating = value; OnPropertyChanged(); _ = SaveLogAsync(); }
+    }
+
+    public string? LogNotes
+    {
+        get => _logNotes;
+        set { _logNotes = value; OnPropertyChanged(); _ = SaveLogAsync(); }
+    }
+
+    public ICommand AddLogCommand { get; }
+    public ICommand DeleteLogCommand { get; }
+
+    public event Action<Tour>? TourUpdated;
+
+    public TourDetailViewModel(ITourService tourService, ITourLogService tourLogService)
+    {
+        _tourService = tourService;
+        _tourLogService = tourLogService;
+
+        AddLogCommand = new RelayCommand(async _ => await AddLogAsync(), _ => SelectedTour is not null);
+        DeleteLogCommand = new RelayCommand(async _ => await DeleteLogAsync(), _ => SelectedLog is not null);
+    }
+
+    private async Task LoadLogsAsync(Guid tourId)
+    {
+        Logs.Clear();
+        var logs = await _tourLogService.GetByTourAsync(tourId);
+        foreach (var l in logs) Logs.Add(l);
+    }
+
+    private async Task AddLogAsync()
+    {
+        if (SelectedTour is null) return;
+        var log = await _tourLogService.CreateAsync(SelectedTour.Id, DateTime.Today, "", 3);
+        Logs.Add(log);
+        Log.Information("Added log to tour {TourName}", SelectedTour.Name);
+    }
+
+    private async Task DeleteLogAsync()
+    {
+        if (SelectedLog is null) return;
+        await _tourLogService.DeleteAsync(SelectedLog.Id);
+        Logs.Remove(SelectedLog);
+        SelectedLog = null;
+    }
+
+    private async Task SaveTourAsync()
+    {
+        if (SelectedTour is null) return;
+        var updated = SelectedTour with { Name = Name ?? "", Description = Description, DistanceKm = DistanceKm };
+        await _tourService.UpdateAsync(updated);
+        SelectedTour = updated;
+        TourUpdated?.Invoke(updated);
+    }
+
+    private async Task SaveLogAsync()
+    {
+        if (SelectedLog is null) return;
+        var updated = SelectedLog with { Date = LogDate, Notes = LogNotes, Rating = LogRating };
+        await _tourLogService.UpdateAsync(updated);
+        var idx = Logs.IndexOf(SelectedLog);
+        if (idx >= 0) Logs[idx] = updated;
+        SelectedLog = updated;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }
+

--- a/src/TourPlanner.UI/ViewModels/TourListViewModel.cs
+++ b/src/TourPlanner.UI/ViewModels/TourListViewModel.cs
@@ -1,111 +1,123 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Windows.Input;
 using Serilog;
+using TourPlanner.Application.Interfaces;
+using TourPlanner.Domain.Entities;
 using TourPlanner.UI.Commands;
-using TourPlanner.UI.Models;
 
-namespace TourPlanner.UI.ViewModels
+namespace TourPlanner.UI.ViewModels;
+
+public class TourListViewModel : INotifyPropertyChanged
 {
-    public class TourListViewModel : INotifyPropertyChanged
+    private readonly ITourService _tourService;
+    private string _searchText = "";
+    private Tour? _selectedTour;
+    private bool _isBusy;
+
+    public ObservableCollection<Tour> Tours { get; } = new();
+    public ICollectionView ToursView { get; }
+
+    public event Action<string>? Status;
+
+    public string SearchText
     {
-        private readonly Action<string> _status;
-        private string _searchText = "";
-        private Tour? _selectedTour;
-        private bool _isBusy;
-
-        public ObservableCollection<Tour> Tours { get; }
-        public ICollectionView ToursView { get; }
-
-        public string SearchText
-        {
-            get => _searchText;
-            set { _searchText = value; OnPropertyChanged(); ToursView.Refresh(); }
-        }
-
-        public Tour? SelectedTour
-        {
-            get => _selectedTour;
-            set { _selectedTour = value; OnPropertyChanged(); CommandManager.InvalidateRequerySuggested(); }
-        }
-
-        public bool IsBusy
-        {
-            get => _isBusy;
-            private set { _isBusy = value; OnPropertyChanged(); CommandManager.InvalidateRequerySuggested(); }
-        }
-
-        public ICommand AddCommand { get; }
-        public ICommand DeleteCommand { get; }
-        public ICommand FocusSearchCommand { get; }
-
-        public TourListViewModel(ObservableCollection<Tour> tours, Action<string> statusReporter)
-        {
-            Tours = tours;
-            _status = statusReporter;
-
-            ToursView = CollectionViewSource.GetDefaultView(Tours);
-            ToursView.Filter = FilterBySearch;
-
-            AddCommand = new RelayCommand(_ => Add(), _ => !IsBusy);
-            DeleteCommand = new RelayCommand(_ => Delete(), _ => !IsBusy && SelectedTour is not null);
-            FocusSearchCommand = new RelayCommand(_ => _status("Focus search (Ctrl+F)"));
-        }
-
-        private bool FilterBySearch(object obj)
-        {
-            if (obj is not Tour t) return false;
-            if (string.IsNullOrWhiteSpace(SearchText)) return true;
-            return t.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase);
-        }
-
-        private void Add()
-        {
-            try
-            {
-                IsBusy = true;
-                var nameBase = "New Tour";
-                var name = nameBase;
-                int i = 1;
-                while (Tours.Any(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase)))
-                    name = $"{nameBase} ({i++})";
-
-                var tour = new Tour
-                {
-                    Name = name,
-                    From = "Start",
-                    To = "Finish",
-                    DistanceKm = 1.0
-                };
-                Tours.Add(tour);
-                SelectedTour = tour;
-                _status($"Added: {tour.Name}");
-                Log.Information("Added tour {TourName}", tour.Name);
-            }
-            finally { IsBusy = false; }
-        }
-
-        private void Delete()
-        {
-            if (SelectedTour is null) return;
-            try
-            {
-                IsBusy = true;
-                var name = SelectedTour.Name;
-                Tours.Remove(SelectedTour);
-                SelectedTour = null;
-                _status($"Deleted: {name}");
-                Log.Information("Deleted tour {TourName}", name);
-            }
-            finally { IsBusy = false; }
-        }
-
-        public event PropertyChangedEventHandler? PropertyChanged;
-        protected void OnPropertyChanged([CallerMemberName] string? name = null)
-            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        get => _searchText;
+        set { _searchText = value; OnPropertyChanged(); ToursView.Refresh(); }
     }
+
+    public Tour? SelectedTour
+    {
+        get => _selectedTour;
+        set { _selectedTour = value; OnPropertyChanged(); CommandManager.InvalidateRequerySuggested(); }
+    }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set { _isBusy = value; OnPropertyChanged(); CommandManager.InvalidateRequerySuggested(); }
+    }
+
+    public ICommand AddCommand { get; }
+    public ICommand DeleteCommand { get; }
+    public ICommand FocusSearchCommand { get; }
+
+    public TourListViewModel(ITourService tourService)
+    {
+        _tourService = tourService;
+
+        ToursView = CollectionViewSource.GetDefaultView(Tours);
+        ToursView.Filter = FilterBySearch;
+
+        AddCommand = new RelayCommand(async _ => await AddAsync(), _ => !IsBusy);
+        DeleteCommand = new RelayCommand(async _ => await DeleteAsync(), _ => !IsBusy && SelectedTour is not null);
+        FocusSearchCommand = new RelayCommand(_ => Status?.Invoke("Focus search (Ctrl+F)"));
+
+        _ = LoadToursAsync();
+    }
+
+    public async Task LoadToursAsync()
+    {
+        try
+        {
+            IsBusy = true;
+            Tours.Clear();
+            var tours = await _tourService.GetAllAsync();
+            foreach (var t in tours) Tours.Add(t);
+        }
+        finally { IsBusy = false; }
+    }
+
+    private bool FilterBySearch(object obj)
+    {
+        if (obj is not Tour t) return false;
+        if (string.IsNullOrWhiteSpace(SearchText)) return true;
+        return t.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task AddAsync()
+    {
+        try
+        {
+            IsBusy = true;
+            var tour = await _tourService.CreateAsync("New Tour", null, 1.0);
+            Tours.Add(tour);
+            SelectedTour = tour;
+            Status?.Invoke($"Added: {tour.Name}");
+            Log.Information("Added tour {TourName}", tour.Name);
+        }
+        finally { IsBusy = false; }
+    }
+
+    private async Task DeleteAsync()
+    {
+        if (SelectedTour is null) return;
+        try
+        {
+            IsBusy = true;
+            var name = SelectedTour.Name;
+            await _tourService.DeleteAsync(SelectedTour.Id);
+            Tours.Remove(SelectedTour);
+            SelectedTour = null;
+            Status?.Invoke($"Deleted: {name}");
+            Log.Information("Deleted tour {TourName}", name);
+        }
+        finally { IsBusy = false; }
+    }
+
+    public void ReplaceTour(Tour tour)
+    {
+        var idx = Tours.ToList().FindIndex(t => t.Id == tour.Id);
+        if (idx >= 0) Tours[idx] = tour;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }
+

--- a/src/TourPlanner.UI/Views/TourDetailView.xaml
+++ b/src/TourPlanner.UI/Views/TourDetailView.xaml
@@ -17,7 +17,7 @@
 
         <!-- Header -->
         <TextBlock Grid.Row="0"
-                   Text="{Binding SelectedTour.Name, TargetNullValue=No tour selected}"
+                   Text="{Binding Name, TargetNullValue=No tour selected}"
                    FontSize="18" FontWeight="Semibold" />
 
         <!-- Details -->
@@ -33,26 +33,19 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="8"/>
                     <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="8"/>
-                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Text="Name:"/>
                 <TextBox Grid.Row="0" Grid.Column="1"
-                         Text="{Binding SelectedTour.Name, UpdateSourceTrigger=PropertyChanged, ValidatesOnNotifyDataErrors=True}"
-                         ToolTip="≥ 3 characters" />
+                         Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" />
 
-                <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="From:"/>
+                <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Text="Description:"/>
                 <TextBox Grid.Row="2" Grid.Column="1"
-                         Text="{Binding SelectedTour.From, UpdateSourceTrigger=PropertyChanged}" />
+                         Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}" />
 
-                <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Text="To:"/>
+                <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Text="Distance (km):"/>
                 <TextBox Grid.Row="4" Grid.Column="1"
-                         Text="{Binding SelectedTour.To, UpdateSourceTrigger=PropertyChanged}" />
-
-                <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center" Text="Distance (km):"/>
-                <TextBox Grid.Row="6" Grid.Column="1"
-                         Text="{Binding SelectedTour.DistanceKm, UpdateSourceTrigger=PropertyChanged, StringFormat=F1}" />
+                         Text="{Binding DistanceKm, UpdateSourceTrigger=PropertyChanged, StringFormat=F1}" />
             </Grid>
         </GroupBox>
 
@@ -63,6 +56,8 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="8"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="8"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <DataGrid Grid.Row="0"
@@ -70,7 +65,7 @@
                           SelectedItem="{Binding SelectedLog}"
                           AutoGenerateColumns="False"
                           CanUserAddRows="False"
-                          IsReadOnly="False">
+                          IsReadOnly="True">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Date" Binding="{Binding Date, StringFormat=\{0:yyyy-MM-dd\}}" Width="*" />
                         <DataGridTextColumn Header="Rating" Binding="{Binding Rating}" Width="*" />
@@ -78,7 +73,22 @@
                     </DataGrid.Columns>
                 </DataGrid>
 
-                <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+                <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,0">
+                    <StackPanel Orientation="Vertical" Margin="0,0,8,0">
+                        <TextBlock Text="Date"/>
+                        <DatePicker SelectedDate="{Binding LogDate, UpdateSourceTrigger=PropertyChanged}"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Vertical" Margin="0,0,8,0">
+                        <TextBlock Text="Rating"/>
+                        <TextBox Width="40" Text="{Binding LogRating, UpdateSourceTrigger=PropertyChanged}"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Vertical" Width="200">
+                        <TextBlock Text="Notes"/>
+                        <TextBox Text="{Binding LogNotes, UpdateSourceTrigger=PropertyChanged}"/>
+                    </StackPanel>
+                </StackPanel>
+
+                <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
                     <Button Content="Add Log" Command="{Binding AddLogCommand}" Margin="0,0,8,0"/>
                     <Button Content="Delete Log" Command="{Binding DeleteLogCommand}" />
                 </StackPanel>


### PR DESCRIPTION
## Summary
- load and manage tours through ITourService and ITourLogService
- register tour-related view models with DI and inject required services
- update tour detail view to edit domain entities and logs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while attempting dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68b5815e4b24832396e44e854eea606a