### PR TITLE
Include log data in tour search

### DIFF
--- a/tests/TourPlanner.Tests/Services/TourServiceContainsLogTests.cs
+++ b/tests/TourPlanner.Tests/Services/TourServiceContainsLogTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Reflection;
+using TourPlanner.Application.Services;
+using TourPlanner.Domain.Entities;
+using TourPlanner.Tests.Utils;
+using Xunit;
+
+namespace TourPlanner.Tests.Services;
+
+public class TourServiceContainsLogTests
+{
+    private static bool InvokeContains(Tour tour, IReadOnlyList<TourLog> logs, int popularity, double? child, string text)
+    {
+        var m = typeof(TourService).GetMethod("Contains", BindingFlags.NonPublic | BindingFlags.Static);
+        return (bool)(m?.Invoke(null, new object?[] { tour, logs, popularity, child, text }) ?? false);
+    }
+
+    [Fact]
+    public void Contains_Finds_By_Log_Comment()
+    {
+        var tour = TestHelper.NewTour("T1", 1);
+        var logs = new List<TourLog> { TestHelper.NewLog(tour.Id, "wonderful", 3) };
+        Assert.True(InvokeContains(tour, logs, 0, null, "wonder"));
+    }
+
+    [Fact]
+    public void Contains_Finds_By_Log_Rating()
+    {
+        var tour = TestHelper.NewTour("T2", 1);
+        var logs = new List<TourLog> { TestHelper.NewLog(tour.Id, string.Empty, 5) };
+        Assert.True(InvokeContains(tour, logs, 0, null, "5"));
+    }
+}


### PR DESCRIPTION
## Summary
- extend tour list search to inspect cached log details (comments, ratings, difficulty, distance and time)
- preload log entries for tours and match average rating
- add tests proving service search matches log comment and rating

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5de5c2fc883239480447ac83414d4