### PR TITLE
Add upvote functionality for tour logs

### DIFF
--- a/src/TourPlanner.Application/Interfaces/ITourLogService.cs
+++ b/src/TourPlanner.Application/Interfaces/ITourLogService.cs
@@ -8,5 +8,6 @@ public interface ITourLogService
     Task<IReadOnlyList<TourLog>> GetByTourAsync(Guid tourId, CancellationToken ct = default);
     Task<TourLog> CreateAsync(Guid tourId, DateTime date, string? comment, int difficulty, double totalDistance, TimeSpan totalTime, int rating, CancellationToken ct = default);
     Task UpdateAsync(TourLog log, CancellationToken ct = default);
+    Task<TourLog> UpvoteAsync(TourLog log, CancellationToken ct = default);
     Task DeleteAsync(Guid id, CancellationToken ct = default);
 }

--- a/src/TourPlanner.Application/Services/TourLogService.cs
+++ b/src/TourPlanner.Application/Services/TourLogService.cs
@@ -30,7 +30,7 @@ public sealed class TourLogService : ITourLogService
             DateTimeKind.Local => date.ToUniversalTime(),
             _ => date
         };
-        var log = new TourLog(Guid.NewGuid(), tourId, utcDate, comment?.Trim(), difficulty, totalDistance, totalTime, rating);
+        var log = new TourLog(Guid.NewGuid(), tourId, utcDate, comment?.Trim(), difficulty, totalDistance, totalTime, rating, 0);
         _log.LogInformation("Creating log for tour {TourId}", tourId);
         return await _repo.CreateAsync(log, ct);
     }
@@ -49,6 +49,14 @@ public sealed class TourLogService : ITourLogService
             _ => log.Date
         };
         await _repo.UpdateAsync(log with { Comment = log.Comment?.Trim(), Date = utcDate }, ct);
+    }
+
+    public async Task<TourLog> UpvoteAsync(TourLog log, CancellationToken ct = default)
+    {
+        _log.LogInformation("Upvoting log {Id}", log.Id);
+        var updated = log with { Votes = log.Votes + 1 };
+        await _repo.UpdateAsync(updated, ct);
+        return updated;
     }
 
     public async Task DeleteAsync(Guid id, CancellationToken ct = default)

--- a/src/TourPlanner.Domain/Entities/TourLog.cs
+++ b/src/TourPlanner.Domain/Entities/TourLog.cs
@@ -10,5 +10,6 @@ public record TourLog(
     int Difficulty,
     double TotalDistance,
     TimeSpan TotalTime,
-    int Rating  // 1..5
+    int Rating,  // 1..5
+    int Votes = 0
 );

--- a/src/TourPlanner.Infrastructure/Migrations/20240718000000_AddTourLogVotes.Designer.cs
+++ b/src/TourPlanner.Infrastructure/Migrations/20240718000000_AddTourLogVotes.Designer.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TourPlanner.Infrastructure.Persistence;
 
@@ -10,9 +11,10 @@ using TourPlanner.Infrastructure.Persistence;
 namespace TourPlanner.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240718000000_AddTourLogVotes")]
+    partial class AddTourLogVotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "8.0.7")
@@ -84,9 +86,6 @@ namespace TourPlanner.Infrastructure.Migrations
                 b.Property<int>("Rating")
                     .HasColumnType("integer");
 
-                b.Property<int>("Votes")
-                    .HasColumnType("integer");
-
                 b.Property<double>("TotalDistance")
                     .HasPrecision(9, 2)
                     .HasColumnType("numeric(9,2)");
@@ -96,6 +95,9 @@ namespace TourPlanner.Infrastructure.Migrations
 
                 b.Property<Guid>("TourId")
                     .HasColumnType("uuid");
+
+                b.Property<int>("Votes")
+                    .HasColumnType("integer");
 
                 b.HasKey("Id");
 

--- a/src/TourPlanner.Infrastructure/Migrations/20240718000000_AddTourLogVotes.cs
+++ b/src/TourPlanner.Infrastructure/Migrations/20240718000000_AddTourLogVotes.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TourPlanner.Infrastructure.Migrations
+{
+    public partial class AddTourLogVotes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Votes",
+                table: "TourLogs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Votes",
+                table: "TourLogs");
+        }
+    }
+}

--- a/src/TourPlanner.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/TourPlanner.Infrastructure/Persistence/AppDbContext.cs
@@ -48,6 +48,7 @@ public sealed class AppDbContext : DbContext
         {
             e.HasKey(x => x.Id);
             e.Property(x => x.Rating).IsRequired();
+            e.Property(x => x.Votes).IsRequired();
             e.Property(x => x.TotalDistance).HasPrecision(9, 2);
             e.HasIndex(x => new { x.TourId, x.Date });
             e.HasIndex(x => new { x.TourId, x.Rating });

--- a/src/TourPlanner.Infrastructure/Repositories/EfTourLogRepository.cs
+++ b/src/TourPlanner.Infrastructure/Repositories/EfTourLogRepository.cs
@@ -16,7 +16,8 @@ public sealed class EfTourLogRepository : ITourLogRepository
         ct.ThrowIfCancellationRequested();
         return await _db.TourLogs.AsNoTracking()
             .Where(x => x.TourId == tourId)
-            .OrderByDescending(x => x.Date)
+            .OrderByDescending(x => x.Votes)
+            .ThenByDescending(x => x.Date)
             .ThenByDescending(x => x.Rating)
             .ToListAsync(ct);
     }

--- a/src/TourPlanner.Infrastructure/Repositories/InMemoryTourLogRepository.cs
+++ b/src/TourPlanner.Infrastructure/Repositories/InMemoryTourLogRepository.cs
@@ -15,7 +15,8 @@ public sealed class InMemoryTourLogRepository : ITourLogRepository
         ct.ThrowIfCancellationRequested();
         var list = _logs
             .Where(l => l.TourId == tourId)
-            .OrderBy(l => l.Date)
+            .OrderByDescending(l => l.Votes)
+            .ThenByDescending(l => l.Date)
             .ToList();
         return Task.FromResult((IReadOnlyList<TourLog>)list);
     }

--- a/src/TourPlanner.UI/Views/TourDetailView.xaml
+++ b/src/TourPlanner.UI/Views/TourDetailView.xaml
@@ -103,6 +103,14 @@
                           CanUserAddRows="False"
                           IsReadOnly="True">
                     <DataGrid.Columns>
+                        <DataGridTextColumn Header="Votes" Binding="{Binding Votes}" Width="Auto" />
+                        <DataGridTemplateColumn Header="Upvote" Width="Auto">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="▲" Command="{Binding DataContext.UpvoteLogCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}" CommandParameter="{Binding}" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                         <DataGridTextColumn Header="Date" Binding="{Binding Date, StringFormat=\{0:yyyy-MM-dd\}}" Width="*" />
                         <DataGridTextColumn Header="Difficulty" Binding="{Binding Difficulty}" Width="*" />
                         <DataGridTextColumn Header="Distance" Binding="{Binding TotalDistance, StringFormat={}{0:F1}}" Width="*" />

--- a/tests/TourPlanner.Tests/Services/TourLogServiceUpvoteTests.cs
+++ b/tests/TourPlanner.Tests/Services/TourLogServiceUpvoteTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using TourPlanner.Application.Interfaces;
+using TourPlanner.Application.Services;
+using TourPlanner.Infrastructure.Repositories;
+using Xunit;
+
+namespace TourPlanner.Tests.Services;
+
+public class TourLogServiceUpvoteTests
+{
+    [Fact]
+    public async Task Upvote_Increments_Count_And_Sorts()
+    {
+        ITourLogRepository repo = new InMemoryTourLogRepository();
+        var service = new TourLogService(repo, NullLogger<TourLogService>.Instance);
+        var tourId = Guid.NewGuid();
+        var l1 = await service.CreateAsync(tourId, DateTime.Today, "A", 1, 0, TimeSpan.Zero, 3);
+        var l2 = await service.CreateAsync(tourId, DateTime.Today, "B", 1, 0, TimeSpan.Zero, 3);
+        await service.UpvoteAsync(l2);
+        var logs = await service.GetByTourAsync(tourId);
+        Assert.Equal(l2.Id, logs[0].Id);
+        Assert.Equal(1, logs[0].Votes);
+        Assert.Equal(0, logs[1].Votes);
+    }
+}

--- a/tests/TourPlanner.Tests/Utils/TestHelper.cs
+++ b/tests/TourPlanner.Tests/Utils/TestHelper.cs
@@ -10,6 +10,6 @@ public static class TestHelper
         => new(Guid.NewGuid(), name, null, "A", "B", "car", distance, TimeSpan.Zero,
             new List<(double,double)>(), string.Empty);
 
-    public static TourLog NewLog(Guid tourId, string comment, int rating)
-        => new(Guid.NewGuid(), tourId, DateTime.Today, comment, 1, 0, TimeSpan.Zero, rating);
+    public static TourLog NewLog(Guid tourId, string comment, int rating, int votes = 0)
+        => new(Guid.NewGuid(), tourId, DateTime.Today, comment, 1, 0, TimeSpan.Zero, rating, votes);
 }


### PR DESCRIPTION
## Summary
- allow tour logs to store vote counts and sort logs by popularity
- expose an `UpvoteAsync` service method and hook it to a new UI command and button
- add EF migration and tests for log upvoting